### PR TITLE
Fix null result for count in WarmUpCommand

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -61,7 +61,7 @@ class WarmupCommand extends Command
         foreach ($extensionKeys as $extensionKey) {
             $output->write($extensionKey . ':');
             $results = $service->warmup($extensionKey)[$extensionKey];
-            $numberOfTemplates = count($results['results']) ?: 0;
+            $numberOfTemplates = count($results['results'] ?? 0);
 
             if ($numberOfTemplates === 0) {
                 $output->write(' ' . 0, true);

--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -61,7 +61,7 @@ class WarmupCommand extends Command
         foreach ($extensionKeys as $extensionKey) {
             $output->write($extensionKey . ':');
             $results = $service->warmup($extensionKey)[$extensionKey];
-            $numberOfTemplates = count($results['results'] ?? 0);
+            $numberOfTemplates = count($results['results'] ?? []);
 
             if ($numberOfTemplates === 0) {
                 $output->write(' ' . 0, true);


### PR DESCRIPTION
The result variable might be null if the extension (e.g. extbase) has no templates to precompile. 

Before the fix: ./vendor/bin/typo3cms fluid:warmup -e extbase throws an exception, because of null as return type
After the fix: ./vendor/bin/typo3cms fluid:warmup -e extbase returns 0 templates to precompile