### PR TITLE
Fix precompile cache action in backend

### DIFF
--- a/Classes/ClearCacheMenu/FluidCacheRegenerateCacheAction.php
+++ b/Classes/ClearCacheMenu/FluidCacheRegenerateCacheAction.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace NamelessCoder\CmsFluidPrecompilerModule\ClearCacheMenu;
 

--- a/Classes/ClearCacheMenu/FluidCacheRegenerateCacheAction.php
+++ b/Classes/ClearCacheMenu/FluidCacheRegenerateCacheAction.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace NamelessCoder\CmsFluidPrecompilerModule\ClearCacheMenu;
 
 use TYPO3\CMS\Backend\Routing\UriBuilder;

--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -61,7 +61,7 @@ class WarmupCommand extends Command
         foreach ($extensionKeys as $extensionKey) {
             $output->write($extensionKey . ':');
             $results = $service->warmup($extensionKey)[$extensionKey];
-            $numberOfTemplates = count($results['results']) ?: 0;
+            $numberOfTemplates = count($results['results'] ?? []);
 
             if ($numberOfTemplates === 0) {
                 $output->write(' ' . 0, true);

--- a/Classes/Controller/FluidPrecompileController.php
+++ b/Classes/Controller/FluidPrecompileController.php
@@ -16,7 +16,7 @@ class FluidPrecompileController
     /**
      * @param ServerRequestInterface|null $request
      * @param ResponseInterface|null $response
-     * @return ResponseInterface
+     * @return ResponseInterface|null
      */
     public function precompileAction(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {

--- a/Classes/Controller/FluidPrecompileController.php
+++ b/Classes/Controller/FluidPrecompileController.php
@@ -1,7 +1,10 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace NamelessCoder\CmsFluidPrecompilerModule\Controller;
 
 use NamelessCoder\CmsFluidPrecompilerModule\Service\FluidPrecompilerService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 
@@ -13,8 +16,10 @@ class FluidPrecompileController
     /**
      * @return void
      */
-    public function precompileAction()
+    public function precompileAction(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         GeneralUtility::makeInstance(ObjectManager::class)->get(FluidPrecompilerService::class)->warmup();
+
+        return $response;
     }
 }

--- a/Classes/Controller/FluidPrecompileController.php
+++ b/Classes/Controller/FluidPrecompileController.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace NamelessCoder\CmsFluidPrecompilerModule\Controller;
 
@@ -14,9 +14,11 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 class FluidPrecompileController
 {
     /**
-     * @return void
+     * @param ServerRequestInterface|null $request
+     * @param ResponseInterface|null $response
+     * @return ResponseInterface
      */
-    public function precompileAction(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    public function precompileAction(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {
         GeneralUtility::makeInstance(ObjectManager::class)->get(FluidPrecompilerService::class)->warmup();
 


### PR DESCRIPTION
The precompile backend action (system toolbar) is now compatible with the request and response interface